### PR TITLE
fix(Button-component): link clickable outside of div

### DIFF
--- a/src/global-components/Button.tsx
+++ b/src/global-components/Button.tsx
@@ -8,15 +8,17 @@ interface Props {
 }
 
 const baseStyle: string =
-  "w-full sm:w-max text-center py-2 px-4 border-solid border-2 rounded transition-all hover:scale-110";
+  "block w-full sm:w-max text-center py-2 px-4 border-solid border-2 rounded transition-all hover:scale-110";
 
 const defaultStyle: string = "bg-white text-black border-black";
 
 function Button({children, url, buttonStyle = defaultStyle}: Props) {
   return (
-    <Link to={url}>
-      <div className={`${baseStyle} ${buttonStyle}`}>{children}</div>
-    </Link>
+    <div>
+      <Link className={`${baseStyle} ${buttonStyle}`} to={url}>
+        {children}
+      </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
the link was containing the div with the style that meant that if its parent was a block level the link was clickable for all it's length.
inverted the position of the link component and the div so that now the link is contained into the div